### PR TITLE
BSのベースデータ作成

### DIFF
--- a/tougi.html
+++ b/tougi.html
@@ -416,6 +416,12 @@
                 this.elementLevel = elementLevel;
                 this.compatibleRange = compatibleRange;
 
+                this.badsStatus = {
+                    curse: { remainingTurns: 0, recovery: false }, // 呪いの状態
+                    poison: { remainingTurns: 0, recovery: false }, // 毒の状態
+                    // 他のBS（例えば睡眠など）もここに追加可能
+                };
+
                 this.alive = true;
                 this.passed = false;
                 this.actionPoints = 0;
@@ -426,6 +432,41 @@
                 this.judgePoints = 0;
                 this.nextAction = null;
                 this.rangeHitFix;
+            }
+
+            // BS処理を行うメソッド
+            processBadStatus() {
+                // 呪いがかかっている場合、呪いだけ回復し他のBSはスキップ
+                if (this.badsStatus.curse.remainingTurns > 0) {
+                    this.handleCurse();
+                } else {
+                    // 呪い以外のBSの回復処理
+                    if (this.badsStatus.poison.remainingTurns > 0) {
+                        this.handlePoison();
+                    }
+                    // 他のBSの処理をここに追加
+                }
+            }
+
+            // 毒の自然回復処理
+            handlePoison() {
+                if (this.badsStatus.poison.remainingTurns > 0) {
+                    // 毒ダメージ: 毎ターンHPの1%を失うが、最小50、最大200まで
+                    let damage = Math.max(50, Math.min(200, Math.floor(this.hp * 0.01)));
+                    this.hp -= damage;
+                    this.hp = Math.max(0, this.hp); // HPが0以下にならないように
+                    this.badsStatus.poison.remainingTurns--;
+                    log(`${this.name}は毒の影響を受けている！ 毒ダメージ: ${damage} 残りターン: ${this.badsStatus.poison.remainingTurns}`);
+                }
+                // 毒が残りターン0になると回復する
+                if (this.badsStatus.poison.remainingTurns === 0) {
+                this.badsStatus.poison.recovery = true;
+                log(`${this.name}の毒が治癒しました！`);
+                }
+            }
+            // HPが0以下かどうかを判定するメソッド
+            isAlive() {
+                return this.hp > 0;
             }
 
             // ダメージを受けるメソッド
@@ -890,6 +931,13 @@
             battleLog.scrollTop = battleLog.scrollHeight;
         }
 
+        function applyPoisonManually(character) {
+        // 毒の状態を直接設定
+        character.badsStatus.poison.remainingTurns = 3;  // 例えば、毒を3ターンに設定
+        character.badsStatus.poison.recovery = false;  // 毒の自然回復を初期化
+        log(`${character.name}に毒が付与されました！`);
+        }
+
         function startBattle() {
             player1 = new Character(
                 document.getElementById('player1_name').value,
@@ -959,6 +1007,11 @@
                 log(`\nターン ${turn}:`);
                 player1.passed = false;
                 player2.passed = false;
+
+                player1.processBadStatus();
+                player2.processBadStatus();
+
+                applyPoisonManually(player1);
 
                 // BS判定フェーズ
                 // ダメージバッドステータスのダメージ処理


### PR DESCRIPTION
- プレイヤーのBS状態を参照する this.badsStatus を追加
- プレイヤーがBS認識、BSの効果発動、BSの自然回復処理のメソッドを追加
- 呪いがかかっている場合、呪い以外のBSは自然回復しない

試験的に毒、呪いのBSのみ追加
applyPoisonManually(player1); が1014行目に入っている為、プレイヤー1はターン開始時毒に侵されます
要検証